### PR TITLE
Update Dockerfile to new client version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER André Camilo <andrejcamilo@gmail.com>
 
 # Download bitbucket backup client
 
-ENV BITBUCKET_BACKUP_CLIENT_VERSION 2.0.1
+ENV BITBUCKET_BACKUP_CLIENT_VERSION 3.3.4
 
 RUN curl -Lks https://maven.atlassian.com/service/local/repositories/atlassian-closedsource-no-sources/content/com/atlassian/bitbucket/server/backup/bitbucket-backup-distribution/${BITBUCKET_BACKUP_CLIENT_VERSION}/bitbucket-backup-distribution-${BITBUCKET_BACKUP_CLIENT_VERSION}.zip -o /root/bitbucket-backup-client.zip
 RUN mkdir /opt/bitbucket


### PR DESCRIPTION
Client version according to https://marketplace.atlassian.com/apps/1211500/bitbucket-server-backup-client/version-history

Note: couldn't build docker image in my machine:
```

Step 6/17 : RUN unzip /root/bitbucket-backup-client.zip -d /opt/bitbucket
 ---> Running in 2ac9662fcd38
Archive:  /root/bitbucket-backup-client.zip
  End-of-central-directory signature not found.  Either this file is not
  a zipfile, or it constitutes one disk of a multi-part archive.  In the
  latter case the central directory and zipfile comment will be found on
  the last disk(s) of this archive.
unzip:  cannot find zipfile directory in one of /root/bitbucket-backup-client.zip or
        /root/bitbucket-backup-client.zip.zip, and cannot find /root/bitbucket-backup-client.zip.ZIP, period.
```